### PR TITLE
Fix errors in README.md

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ any other name that you have configured).  Then you have to update
 PREDEFINED value in your doxygen configuration file with correct block name.
 You also have to set ENABLE_PREPROCESSING to YES.
 
-Generate a doxygen group (begining and ending). The tag text is
+Generate a doxygen group (beginning and ending). The tag text is
 configurable.
 
 Use:


### PR DESCRIPTION
21: Generate a doxygen group (begining and ending). The tag text is -> Generate a doxygen group (beginning and ending). The tag text is
59: at least on the third line after current cursor position. -> at least on the third line after the current cursor position.

FIX #15